### PR TITLE
Expose error response json in case extra parameters are given

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.1'
         classpath 'org.jacoco:org.jacoco.core:0.8.7'
     }
@@ -23,21 +23,9 @@ subprojects {
 
 ext.verifyKeystore()
 
-try {
-    def grgit = Grgit.open(currentDir: project.rootDir)
-    def lastCommit = grgit.head()
-
-    project.ext.versionNum = grgit.log(includes:['HEAD']).size()
-    project.ext.versionName = grgit.describe()
-    project.ext.versionDate = lastCommit.getDate()
-    if (project.ext.versionName == null) {
-        project.ext.versionName = 'DEV'
-    }
-} catch (Exception ignored) {
-    project.ext.versionNum = 1
-    project.ext.versionName = 'DEV'
-    project.ext.versionDate = new Date()
-}
+project.ext.versionNum = 1
+project.ext.versionName = '0.11.1-agile'
+project.ext.versionDate = new Date()
 
 project.ext {
     minSdkVersion = 16

--- a/library/java/net/openid/appauth/AuthorizationException.java
+++ b/library/java/net/openid/appauth/AuthorizationException.java
@@ -32,11 +32,9 @@ import java.util.Map;
 
 /**
  * Returned as a response to OAuth2 requests if they fail. Specifically:
- *
  * - The {@link net.openid.appauth.AuthorizationService.TokenResponseCallback response} to
  * {@link AuthorizationService#performTokenRequest(net.openid.appauth.TokenRequest,
  * AuthorizationService.TokenResponseCallback) token requests},
- *
  * - The {@link net.openid.appauth.AuthorizationServiceConfiguration.RetrieveConfigurationCallback
  * response}
  * to
@@ -464,22 +462,22 @@ public final class AuthorizationException extends Exception {
 
     private static AuthorizationException generalEx(int code, @Nullable String errorDescription) {
         return new AuthorizationException(
-                TYPE_GENERAL_ERROR, code, null, errorDescription, null, null);
+                TYPE_GENERAL_ERROR, code, null, errorDescription, null, null, null);
     }
 
     private static AuthorizationException authEx(int code, @Nullable String error) {
         return new AuthorizationException(
-                TYPE_OAUTH_AUTHORIZATION_ERROR, code, error, null, null, null);
+                TYPE_OAUTH_AUTHORIZATION_ERROR, code, error, null, null, null, null);
     }
 
     private static AuthorizationException tokenEx(int code, @Nullable String error) {
         return new AuthorizationException(
-                TYPE_OAUTH_TOKEN_ERROR, code, error, null, null, null);
+                TYPE_OAUTH_TOKEN_ERROR, code, error, null, null, null, null);
     }
 
     private static AuthorizationException registrationEx(int code, @Nullable String error) {
         return new AuthorizationException(
-                TYPE_OAUTH_REGISTRATION_ERROR, code, error, null, null, null);
+                TYPE_OAUTH_REGISTRATION_ERROR, code, error, null, null, null, null);
     }
 
     /**
@@ -496,6 +494,7 @@ public final class AuthorizationException extends Exception {
                 ex.error,
                 ex.errorDescription,
                 ex.errorUri,
+                ex.responseJson,
                 rootCause);
     }
 
@@ -508,13 +507,15 @@ public final class AuthorizationException extends Exception {
             @NonNull AuthorizationException ex,
             @Nullable String errorOverride,
             @Nullable String errorDescriptionOverride,
-            @Nullable Uri errorUriOverride) {
+            @Nullable Uri errorUriOverride,
+            @Nullable JSONObject responseJson) {
         return new AuthorizationException(
                 ex.type,
                 ex.code,
                 (errorOverride != null) ? errorOverride : ex.error,
                 (errorDescriptionOverride != null) ? errorDescriptionOverride : ex.errorDescription,
                 (errorUriOverride != null) ? errorUriOverride : ex.errorUri,
+                responseJson,
                 null);
     }
 
@@ -533,6 +534,7 @@ public final class AuthorizationException extends Exception {
                 error,
                 errorDescription != null ? errorDescription : base.errorDescription,
                 errorUri != null ? Uri.parse(errorUri) : base.errorUri,
+                base.responseJson,
                 null);
     }
 
@@ -559,6 +561,7 @@ public final class AuthorizationException extends Exception {
                 JsonUtil.getStringIfDefined(json, KEY_ERROR),
                 JsonUtil.getStringIfDefined(json, KEY_ERROR_DESCRIPTION),
                 JsonUtil.getUriIfDefined(json, KEY_ERROR_URI),
+                json,
                 null);
     }
 
@@ -632,6 +635,12 @@ public final class AuthorizationException extends Exception {
     public final Uri errorUri;
 
     /**
+     * The raw error json object
+     */
+    @Nullable
+    public final JSONObject responseJson;
+
+    /**
      * Instantiates an authorization request with optional root cause information.
      */
     public AuthorizationException(
@@ -640,6 +649,7 @@ public final class AuthorizationException extends Exception {
             @Nullable String error,
             @Nullable String errorDescription,
             @Nullable Uri errorUri,
+            @Nullable JSONObject responseJson,
             @Nullable Throwable rootCause) {
         super(errorDescription, rootCause);
         this.type = type;
@@ -647,6 +657,7 @@ public final class AuthorizationException extends Exception {
         this.error = error;
         this.errorDescription = errorDescription;
         this.errorUri = errorUri;
+        this.responseJson = responseJson;
     }
 
     /**

--- a/library/java/net/openid/appauth/AuthorizationService.java
+++ b/library/java/net/openid/appauth/AuthorizationService.java
@@ -52,7 +52,6 @@ import java.net.HttpURLConnection;
 import java.net.URLConnection;
 import java.util.Map;
 
-
 /**
  * Dispatches requests to an OAuth2 authorization service. Note that instances of this class
  * _must be manually disposed_ when no longer required, to avoid leaks
@@ -673,7 +672,8 @@ public class AuthorizationService {
                             error,
                             json.optString(AuthorizationException.PARAM_ERROR_DESCRIPTION, null),
                             UriUtil.parseUriIfAvailable(
-                                    json.optString(AuthorizationException.PARAM_ERROR_URI)));
+                                    json.optString(AuthorizationException.PARAM_ERROR_URI)),
+                            json);
                 } catch (JSONException jsonEx) {
                     ex = AuthorizationException.fromTemplate(
                             GeneralErrors.JSON_DESERIALIZATION_ERROR,
@@ -742,7 +742,6 @@ public class AuthorizationService {
     public interface TokenResponseCallback {
         /**
          * Invoked when the request completes successfully or fails.
-         *
          * Exactly one of `response` or `ex` will be non-null. If `response` is `null`, a failure
          * occurred during the request. This can happen if a bad URI was provided, no connection
          * to the server could be established, or the response JSON was incomplete or incorrectly
@@ -821,7 +820,8 @@ public class AuthorizationService {
                             error,
                             json.getString(AuthorizationException.PARAM_ERROR_DESCRIPTION),
                             UriUtil.parseUriIfAvailable(
-                                    json.getString(AuthorizationException.PARAM_ERROR_URI)));
+                                    json.getString(AuthorizationException.PARAM_ERROR_URI)),
+                            json);
                 } catch (JSONException jsonEx) {
                     ex = AuthorizationException.fromTemplate(
                             GeneralErrors.JSON_DESERIALIZATION_ERROR,
@@ -862,7 +862,6 @@ public class AuthorizationService {
     public interface RegistrationResponseCallback {
         /**
          * Invoked when the request completes successfully or fails.
-         *
          * Exactly one of `response` or `ex` will be non-null. If `response` is `null`, a failure
          * occurred during the request. This can happen if an invalid URI was provided, no
          * connection to the server could be established, or the response JSON was incomplete or


### PR DESCRIPTION
<!-- Thank you for your contribution! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I read the [Contribution Guidelines](https://github.com/openid/AppAuth-Android/blob/master/CONTRIBUTING.md)
- [ ] I signed the CLA and WG Agreements <!-- Please provide link if this is your first contribution. -->
- [ ] I ran, updated and added unit tests as necessary.
- [ ] I verified the contribution matches existing coding style.
- [ ] I updated the documentation if necessary.

### Motivation and Context
We have found that some servers will return non-standard parameters along with the standard ones in their error responses, and we see a need for getting access to those parameters. To facilitate this, we would like to pass back the full original error response JSONObject along in the token request callback in the AuthorizationException.

### Description
We held onto the original error response JSONObject and added it as an optional field in the AuthorizationException that is passed to the token request callback.
